### PR TITLE
Removed redundant if-statement

### DIFF
--- a/wicked/helpers/combinatorics.cc
+++ b/wicked/helpers/combinatorics.cc
@@ -1,8 +1,6 @@
 #include "combinatorics.h"
 
 long long int factorial(int n) {
-  if (n == 0)
-    return 1;
   long long int result = 1;
   for (long long int i = 2; i <= n; ++i) {
     result *= i;


### PR DESCRIPTION
The explicit check whether n == 0 is redundant as it is implicitly covered
by the following loop. All it currently does is adding an extra conditional branching
in the cases n != 0.
Therefore it has been removed.