### PR TITLE
Detect and test boost integers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,12 @@ steps:
 
 - script: |
     conda config --set always_yes yes
-    conda install -c conda-forge lcov pytest boost
+    if [ $(boost) = "true" ]
+    then
+      conda install -c conda-forge lcov pytest boost
+    else
+      conda install -c conda-forge lcov pytest
+    fi
   displayName: 'Install lcov'
 
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,11 @@ pool:
   vmImage: ubuntu-latest
 strategy:
   matrix:
-    Python37:
-      python.version: '3.7'
+    Python310:
+      python.version: '3.10'
+    Python310Boost:
+      python.version: '3.10'
+      boost: 'true'
 
 steps:
 - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ strategy:
   matrix:
     Python310:
       python.version: '3.10'
+      boost: 'false'
     Python310Boost:
       python.version: '3.10'
       boost: 'true'
@@ -25,13 +26,14 @@ steps:
 
 - script: |
     conda config --set always_yes yes
-    if [ $(boost) = "true" ]
+    if [ $(boost) = 'true' ]
     then
       conda install -c conda-forge lcov pytest boost
+      echo "##vso[task.setvariable variable=BOOST_ROOT]$(conda info --base)"
     else
       conda install -c conda-forge lcov pytest
     fi
-  displayName: 'Install lcov'
+  displayName: 'Install conda dependencies'
 
 - script: |
     # enable code coverage via setup.cfg

--- a/tests/diag/test_cancellation.py
+++ b/tests/diag/test_cancellation.py
@@ -1,0 +1,33 @@
+import wicked as w
+
+
+def test_cancellation():
+    """Test cancellation of equivalent terms in a specific example involving a general orbital space"""
+    w.reset_space()
+    w.add_space("a", "fermion", "general", ["u", "v", "w", "x", "y", "z"])
+
+    T2 = w.op("t", ["a+ a+ a a"])
+    V = w.op("v", ["a+ a+ a a"])
+
+    wt = w.WickTheorem()
+    wt.do_canonicalize_graph(True)
+    val = wt.contract(w.rational(1), w.commutator(V, T2), 0, 0)
+    ref = w.utils.string_to_expr(
+        """1/4 eta1^{a1}_{a0} eta1^{a3}_{a2} gamma1^{a5}_{a4} gamma1^{a7}_{a6} t^{a4,a6}_{a1,a3} v^{a0,a2}_{a5,a7}
+-1/4 eta1^{a1}_{a0} eta1^{a3}_{a2} gamma1^{a5}_{a4} gamma1^{a7}_{a6} t^{a0,a2}_{a5,a7} v^{a4,a6}_{a1,a3}
++1/8 eta1^{a1}_{a0} eta1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a4,a5}_{a1,a3} v^{a0,a2}_{a6,a7}
+-1/8 eta1^{a1}_{a0} eta1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a0,a2}_{a6,a7} v^{a4,a5}_{a1,a3}
+-eta1^{a1}_{a0} gamma1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a2,a4}_{a1,a7} v^{a0,a5}_{a3,a6}
++eta1^{a1}_{a0} gamma1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a0,a5}_{a3,a6} v^{a2,a4}_{a1,a7}
+-1/4 eta1^{a1}_{a0} lambda3^{a5,a6,a7}_{a2,a3,a4} t^{a2,a3}_{a1,a7} v^{a0,a4}_{a5,a6}
++1/4 eta1^{a1}_{a0} lambda3^{a5,a6,a7}_{a2,a3,a4} t^{a0,a4}_{a5,a6} v^{a2,a3}_{a1,a7}
+-1/8 gamma1^{a1}_{a0} gamma1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a4,a5}_{a1,a3} v^{a0,a2}_{a6,a7}
++1/8 gamma1^{a1}_{a0} gamma1^{a3}_{a2} lambda2^{a6,a7}_{a4,a5} t^{a0,a2}_{a6,a7} v^{a4,a5}_{a1,a3}
+-1/4 gamma1^{a1}_{a0} lambda3^{a5,a6,a7}_{a2,a3,a4} t^{a3,a4}_{a1,a5} v^{a0,a2}_{a6,a7}
++1/4 gamma1^{a1}_{a0} lambda3^{a5,a6,a7}_{a2,a3,a4} t^{a0,a2}_{a6,a7} v^{a3,a4}_{a1,a5}"""
+    )
+    assert val == ref
+
+
+if __name__ == "__main__":
+    test_cancellation()

--- a/tests/diag/test_cc.py
+++ b/tests/diag/test_cc.py
@@ -48,7 +48,16 @@ def cc_equations(n):
         
     return equations
 
-def test_cc_n(max_n):
+def test_cc():
+    """Test the CC equations"""
+    # The case of n = 8 can be tested only if the boost library is available
+    # otherwise we get the wrong number of terms for the CC equations
+    if w.use_boost_1024_int():
+        cc_n(8)
+    else:
+        cc_n(7)
+
+def cc_n(max_n):
     """Evaluate the number of terms in the n-th order CC equations"""
     # The number of terms in the CC equations for n = 0, 1, 2, ..., 8
     diagrams_count_ref = [[1],
@@ -84,7 +93,4 @@ def test_cc_n(max_n):
     assert diagrams_count == diagrams_count_ref[:max_n + 1]       
 
 if __name__ == "__main__":
-    if w.use_boost_1024_int():
-        test_cc_n(8)
-    else:
-        test_cc_n(7)
+    test_cc()

--- a/tests/diag/test_cc.py
+++ b/tests/diag/test_cc.py
@@ -1,0 +1,90 @@
+import wicked as w
+
+
+def print_comparison(val, val2):
+    print(f"Result: {val}")
+    print(f"Test:   {val2}")
+
+
+def compare_expressions(test, ref):
+    test_expr = w.Expression()
+    ref_expr = w.Expression()
+    for s in ref:
+        ref_expr += w.string_to_expr(s)
+    for eq in test:
+        test_expr += eq.rhs_expression()
+    print_comparison(test_expr, ref_expr)
+    assert test_expr == ref_expr
+
+
+def initialize():
+    w.reset_space()
+    w.add_space("o", "fermion", "occupied", ["i", "j", "k", "l", "m", "n"])
+    w.add_space("v", "fermion", "unoccupied", ["a", "b", "c", "d", "e", "f"])
+
+def make_T(n):
+    components = [f"{'v+' * k} {'o' * k}" for k in range(1,n + 1)]
+    return w.op("t",components)
+
+def cc_equations(n):
+    initialize()
+
+    wt = w.WickTheorem()
+
+    E0 = w.op("E_0",[''])
+    F = w.utils.gen_op('f',1,'ov','ov')
+    V = w.utils.gen_op('v',2,'ov','ov')
+    H = E0 + F + V
+
+    T = make_T(n)
+    Hbar = w.bch_series(H,T,4)
+    expr = wt.contract(w.rational(1), Hbar, 0, 2 * n)
+    mbeq = expr.to_manybody_equation("r")
+    
+    equations = {}
+    for r in range(0,n + 1):
+        s = f"{'o' * r}|{'v' * r}" 
+        equations[r] = (mbeq[s])      
+        
+    return equations
+
+def test_cc_n(max_n):
+    """Evaluate the number of terms in the n-th order CC equations"""
+    # The number of terms in the CC equations for n = 0, 1, 2, ..., 8
+    diagrams_count_ref = [[1],
+                [3,8],
+                [4,14,31],
+                [4,15,37,47],
+                [4,15,38,53,74],
+                [4,15,38,54,80,99],
+                [4,15,38,54,81,105,135],
+                [4,15,38,54,81,106,141,169],
+                [4,15,38,54,81,106,142,175,215]]
+    
+    width = 5 * (max_n + 1) + 2
+    print(f'{"=" * width}')
+    print(f' n     Exc. level ')
+    print(f'  {" ".join([f"{k:4d}" for k in range(0,max_n + 1)])}')
+    print(f'{"-" * width}')
+
+    rows = []
+    diagrams_count = []
+    for n in range(0,max_n + 1):
+        equations = cc_equations(n)
+        diagrams_count.append([len(eqs) for _, eqs in equations.items()])
+        count = " ".join([f'{len(eqs):4d}' for k, eqs in equations.items()])
+        rows.append(f' {n}{count}')
+        print(f' {n}{count}')
+
+    print(f'{"=" * width}')  
+
+    print(diagrams_count)
+    print(diagrams_count_ref[:max_n + 1])
+
+    assert diagrams_count == diagrams_count_ref[:max_n + 1]       
+
+if __name__ == "__main__":
+    if w.use_boost_1024_int():
+        test_cc_n(8)
+    else:
+        test_cc_n(7)

--- a/tests/diag/test_odd_ops.py
+++ b/tests/diag/test_odd_ops.py
@@ -1,0 +1,95 @@
+import wicked as w
+
+
+def print_comparison(val, val2):
+    print(f"Result: {val}")
+    print(f"Test:   {val2}")
+
+
+def compare_expressions(test, ref):
+    test_expr = w.Expression()
+    ref_expr = w.Expression()
+    for s in ref:
+        ref_expr += w.string_to_expr(s)
+    for eq in test:
+        test_expr += eq.rhs_expression()
+    print_comparison(test_expr, ref_expr)
+    assert test_expr == ref_expr
+
+
+def initialize():
+    w.reset_space()
+    w.add_space("o", "fermion", "occupied", ["i", "j", "k", "l", "m", "n"])
+    w.add_space("v", "fermion", "unoccupied", ["a", "b", "c", "d", "e", "f"])
+
+
+def test_odd_operators_1():
+    """Test <o+ o>"""
+    initialize()
+    A = w.op("a", ["o+"])
+    B = w.op("b", ["o"])
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), A @ B, 0, 0)
+    val2 = w.expression("a^{}_{o_0} b^{o_0}_{}")
+    print_comparison(val, val2)
+    assert val == val2
+
+
+def test_odd_operators_2():
+    """Test <o o+>"""
+    initialize()
+    A = w.op("a", ["o"])
+    B = w.op("b", ["o+"])
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), A @ B, 0, 0)
+    val2 = w.expression("")
+    print_comparison(val, val2)
+    assert val == val2
+
+
+def test_odd_operators_3():
+    """Test <o+ v o>"""
+    initialize()
+    A = w.op("a", ["o+ v"])
+    B = w.op("b", ["o"])
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), A @ B, 0, 1)
+    val2 = w.expression("-a^{v0}_{o0} b^{o0}_{} a-(v0)")
+    print_comparison(val, val2)
+    assert val == val2
+
+
+def test_odd_operators_4():
+    """Test <o+ o+ o o>, <o+ o+ o o>, and <o o+ o+ o>"""
+    initialize()
+    A = w.op("a", ["o+ o+"])
+    B = w.op("b", ["o"])
+    C = w.op("c", ["o"])
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), A @ B @ C, 0, 0)
+    val2 = w.expression("- a^{}_{o0,o1} b^{o0}_{} c^{o1}_{}")
+    print_comparison(val, val2)
+    assert val == val2
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), A @ C @ B, 0, 0)
+    val2 = w.expression("a^{}_{o0,o1} b^{o0}_{} c^{o1}_{}")
+    print_comparison(val, val2)
+    assert val == val2
+
+    wt = w.WickTheorem()
+    val = wt.contract(w.rational(1), C @ A @ B, 0, 0)
+    val2 = w.expression("")
+    print_comparison(val, val2)
+    assert val == val2
+
+
+if __name__ == "__main__":
+    test_odd_operators_1()
+    test_odd_operators_2()
+    test_odd_operators_3()
+    test_odd_operators_4()

--- a/tests/opexpr/test_opexpr.py
+++ b/tests/opexpr/test_opexpr.py
@@ -1,0 +1,34 @@
+import wicked as w
+
+def test_opexpr1():
+    """Test the definition of an operator expression"""
+    w.reset_space()
+    w.add_space("o", "fermion", "occupied", ["i", "j", "k", "l", "m", "n"])
+    w.add_space("v", "fermion", "unoccupied", ["a", "b", "c", "d", "e", "f"])
+
+    T1 = w.op("t", ["v+ o"])
+    T2 = w.op("t", ["v+ v+ o o"])
+    T3 = T1 + T2
+    T = w.op("t", ["v+ o", "v+ v+ o o"])
+    assert T == T3
+
+def test_opexpr2():
+    """Test the canonicalization of an operator expression"""
+    w.reset_space()
+    w.add_space("o", "fermion", "occupied", ["i", "j", "k", "l", "m", "n"])
+    w.add_space("v", "fermion", "unoccupied", ["a", "b", "c", "d", "e", "f"])
+
+    A = w.op("a", ["v+ v"])
+    B = w.op("b", ["o+ o"])
+    C = w.op("c", ["o+ o"])
+
+    prod = C @ B @ A
+    assert str(prod) == "+ c { o+ o } b { o+ o } a { v+ v }"
+    # if we canonicalize, we get a different ordering but preserve
+    # the order of operators that do not commute
+    prod.canonicalize()
+    assert str(prod) == "+ a { v+ v } c { o+ o } b { o+ o }"
+
+if __name__ == "__main__":
+    test_opexpr1()
+    test_opexpr2()

--- a/wicked/CMakeLists.txt
+++ b/wicked/CMakeLists.txt
@@ -15,4 +15,20 @@ if(CODE_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif(CODE_COVERAGE)
 
+# Look for the Boost libraries
+find_package(Boost)
+
+# Check if Boost was found
+if(Boost_FOUND)
+    message(STATUS "Boost found")
+
+    # Define the USE_BOOST_1024_INT flag
+    add_definitions(-DUSE_BOOST_1024_INT)
+
+    # Add Boost's include directories to the build
+    include_directories(${Boost_INCLUDE_DIRS})
+else()
+    message(STATUS "Boost not found")
+endif()
+
 pybind11_add_module(_wicked ${SRC_LIST} ${module_SOURCES})

--- a/wicked/api/rational_api.cc
+++ b/wicked/api/rational_api.cc
@@ -37,4 +37,6 @@ void export_rational(py::module &m) {
       .def("str", &rational::str);
 
   m.def("make_rational", &make_rational_from_str);
+  m.def("use_boost_1024_int", &use_boost_1024_int,
+        "Return true if 1024-bit integers are used");
 }

--- a/wicked/helpers/rational.cc
+++ b/wicked/helpers/rational.cc
@@ -236,4 +236,8 @@ rational make_rational_from_str(const std::string &s) {
 }
 
 /// return true if boost rational is used
-bool use_boost_1024_int() { return USE_BOOST_1024_INT; }
+#if USE_BOOST_1024_INT
+bool use_boost_1024_int() { return true; }
+#else
+bool use_boost_1024_int() { return false; }
+#endif

--- a/wicked/helpers/rational.cc
+++ b/wicked/helpers/rational.cc
@@ -1,7 +1,7 @@
 #include <numeric>
 #include <regex>
 
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
 #include "boost/lexical_cast.hpp"
 #endif
 
@@ -82,7 +82,7 @@ std::string rational::str(bool sign) const {
         s += "-";
       } else {
         if (numerator_ != 1) {
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
           s += boost::lexical_cast<std::string>(numerator_);
 #else
           s += std::to_string(numerator_);
@@ -90,7 +90,7 @@ std::string rational::str(bool sign) const {
         }
       }
     } else {
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
       s += boost::lexical_cast<std::string>(numerator_) + "/" +
            boost::lexical_cast<std::string>(denominator_);
 #else
@@ -102,7 +102,7 @@ std::string rational::str(bool sign) const {
 }
 
 std::string rational::repr() const {
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
   return "rational(" + boost::lexical_cast<std::string>(numerator_) + "," +
          boost::lexical_cast<std::string>(denominator_) + ")";
 #else
@@ -122,7 +122,7 @@ std::string rational::latex() const {
       } else if (numerator_ == -1) {
         s += "-";
       } else {
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
         s += boost::lexical_cast<std::string>(numerator_);
 #else
         s += std::to_string(numerator_);
@@ -134,10 +134,9 @@ std::string rational::latex() const {
       } else {
         s += "-";
       }
-#if USE_BOOST_RATIONAL
-      s += "\\frac{" +
-           boost::lexical_cast<std::string>(boost::abs(numerator_)) + "}{" +
-           boost::lexical_cast<std::string>(denominator_) + "}";
+#if USE_BOOST_1024_INT
+      s += "\\frac{" + boost::lexical_cast<std::string>(abs(numerator_)) +
+           "}{" + boost::lexical_cast<std::string>(denominator_) + "}";
 #else
       s += "\\frac{" + std::to_string(std::abs(numerator_)) + "}{" +
            std::to_string(denominator_) + "}";
@@ -190,7 +189,7 @@ std::ostream &operator<<(std::ostream &os, const rational &rhs) {
 
 void rational::reduce() {
 // find the gcd
-#if USE_BOOST_RATIONAL
+#if USE_BOOST_1024_INT
   rational_t gcd = boost::gcd(numerator_, denominator_);
 #else
   rational_t gcd = std::gcd(numerator_, denominator_);
@@ -235,3 +234,6 @@ rational make_rational_from_str(const std::string &s) {
   }
   return rational(numerator, denominator);
 }
+
+/// return true if boost rational is used
+bool use_boost_1024_int() { return USE_BOOST_1024_INT; }

--- a/wicked/helpers/rational.h
+++ b/wicked/helpers/rational.h
@@ -3,8 +3,12 @@
 
 #include <ostream>
 
-#define USE_BOOST_RATIONAL 0
-#if USE_BOOST_RATIONAL
+/// USE_BOOST_1024_INT is set to true by CMake if boost is found
+/// otherwise, we use long long int.
+/// Note that long long int is not sufficient for all cases.
+/// For example, the CC equations with up to 8-body excitation operators cannot
+/// be handled with long long int.
+#if USE_BOOST_1024_INT
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/rational.hpp>
 using rational_t = boost::multiprecision::int1024_t;
@@ -73,9 +77,11 @@ rational operator-(rational lhs, const rational &rhs);
 rational operator*(rational lhs, const rational &rhs);
 /// division
 rational operator/(rational lhs, const rational &rhs);
-
+/// make a rational from a string
 rational make_rational_from_str(const std::string &s);
-
+/// output a rational to a stream
 std::ostream &operator<<(std::ostream &os, const rational &rhs);
+/// return true if boost rational is used
+bool use_boost_1024_int();
 
 #endif // _wicked_rational_h_


### PR DESCRIPTION
This PR adds detection of boost and will test wick&d with and without boost. When compiled with boost, wick&d will use 1024-bit integers and will be able to properly handle the derivation of the CCSDTQPH78 equations.