### PR TITLE
PyBind improvements, moving `compile` to Python side

### DIFF
--- a/tests/expression/test_expression.py
+++ b/tests/expression/test_expression.py
@@ -38,6 +38,13 @@ def test_expression():
     expr_str = """3/2 { a+(a0) }
 +{ a+(v0) a-(o0) }"""
     assert str(expr) == expr_str
+    for idx, i in enumerate(expr):
+        if (idx == 0): 
+            assert str(i[0])=='{ a+(a0) }' 
+            assert i[1]==w.rational(3,2)
+        if (idx == 1):
+            assert str(i[0])=='{ a+(v0) a-(o0) }'
+            assert i[1]==w.rational(1,1)
 
 
 def test_expression2():

--- a/tests/orbital_space/test_orbital_space.py
+++ b/tests/orbital_space/test_orbital_space.py
@@ -8,6 +8,11 @@ def test_orbital_space():
     w.add_space("a", "fermion", "general", ["u", "v", "w", "x", "y", "z"])
     w.add_space("v", "fermion", "unoccupied", ["e", "f"])
     assert w.num_spaces() == 3
+    osi_dict = w.osi().to_dict()
+    assert set(osi_dict.keys()) == set(["c", "a", "v"])
+    assert set(osi_dict['c']) == set(["m", "n"])
+    assert set(osi_dict['a']) == set(["u", "v", "w", "x", "y", "z"])
+    assert set(osi_dict['v']) == set(["e", "f"])
 
 
 def test_orbital_space_exceptions():

--- a/wicked/api/equation_api.cc
+++ b/wicked/api/equation_api.cc
@@ -14,6 +14,7 @@ void export_Equation(py::module &m) {
       .def("lhs", &Equation::lhs)
       .def("rhs", &Equation::rhs)
       .def("rhs_expression", &Equation::rhs_expression)
+      .def("rhs_factor", &Equation::rhs_factor)
       .def("__repr__", &Equation::str)
       .def("__str__", &Equation::str)
       .def("latex", &Equation::latex)

--- a/wicked/api/expression_api.cc
+++ b/wicked/api/expression_api.cc
@@ -26,6 +26,11 @@ void export_Expression(py::module &m) {
              lhs += rhs;
              return lhs;
            })
+      .def("__iter__",
+           [](Expression &e) {
+             return py::make_iterator(e.begin(), e.end());
+           },
+           py::keep_alive<0, 1>())
       .def("latex", &Expression::latex, "sep"_a = " \\\\ \n")
       .def("to_manybody_equation", &Expression::to_manybody_equation)
       .def("to_manybody_equations", &Expression::to_manybody_equation)

--- a/wicked/api/orbital_space_api.cc
+++ b/wicked/api/orbital_space_api.cc
@@ -16,7 +16,7 @@ void export_OrbitalSpaceInfo(py::module &m) {
       .def("num_spaces", &OrbitalSpaceInfo::num_spaces)
       .def("label", &OrbitalSpaceInfo::label)
       .def("indices", &OrbitalSpaceInfo::indices)
-      .def("to_dict", &OrbitalSpaceInfo::osi_dict)
+      .def("to_dict", &OrbitalSpaceInfo::to_dict)
       .def("__str__", &OrbitalSpaceInfo::str);
 
   m.def("osi", []() { return orbital_subspaces; });

--- a/wicked/api/orbital_space_api.cc
+++ b/wicked/api/orbital_space_api.cc
@@ -15,6 +15,8 @@ void export_OrbitalSpaceInfo(py::module &m) {
       .def("add_space", &OrbitalSpaceInfo::add_space)
       .def("num_spaces", &OrbitalSpaceInfo::num_spaces)
       .def("label", &OrbitalSpaceInfo::label)
+      .def("indices", &OrbitalSpaceInfo::indices)
+      .def("to_dict", &OrbitalSpaceInfo::osi_dict)
       .def("__str__", &OrbitalSpaceInfo::str);
 
   m.def("osi", []() { return orbital_subspaces; });

--- a/wicked/api/term_api.cc
+++ b/wicked/api/term_api.cc
@@ -20,7 +20,8 @@ void export_SymbolicTerm(py::module &m) {
       .def("add", py::overload_cast<const Tensor &>(&SymbolicTerm::add))
       .def("set", py::overload_cast<const std::vector<SQOperator> &>(
                       &SymbolicTerm::set))
-      .def("set_normal_ordered", &SymbolicTerm::set_normal_ordered);
+      .def("set_normal_ordered", &SymbolicTerm::set_normal_ordered)
+      .def("tensors", &SymbolicTerm::tensors);
   ;
 
   py::class_<Term, std::shared_ptr<Term>>(m, "Term")

--- a/wicked/helpers/orbital_space.cc
+++ b/wicked/helpers/orbital_space.cc
@@ -111,6 +111,14 @@ std::string OrbitalSpaceInfo::str() const {
   return join(s, "\n\n");
 }
 
+std::map<std::string, std::vector<std::string>> OrbitalSpaceInfo::osi_dict() const {
+  std::map<std::string, std::vector<std::string>> d;
+  for (const auto &info : space_info_) {
+    d[std::string(1, info.label())] = info.indices();
+  }
+  return d;
+}
+
 char OrbitalSpaceInfo::label(int pos) const { return space_info_[pos].label(); }
 
 const std::string OrbitalSpaceInfo::index_label(int pos, int idx) const {

--- a/wicked/helpers/orbital_space.cc
+++ b/wicked/helpers/orbital_space.cc
@@ -111,7 +111,7 @@ std::string OrbitalSpaceInfo::str() const {
   return join(s, "\n\n");
 }
 
-std::map<std::string, std::vector<std::string>> OrbitalSpaceInfo::osi_dict() const {
+std::map<std::string, std::vector<std::string>> OrbitalSpaceInfo::to_dict() const {
   std::map<std::string, std::vector<std::string>> d;
   for (const auto &info : space_info_) {
     d[std::string(1, info.label())] = info.indices();

--- a/wicked/helpers/orbital_space.h
+++ b/wicked/helpers/orbital_space.h
@@ -82,6 +82,9 @@ public:
   /// return a string representation
   std::string str() const;
 
+  /// Return a dictionary representation
+  std::map<std::string, std::vector<std::string>> osi_dict() const;
+
 private:
   /// Vector of spaces
   std::vector<OrbitalSpace> space_info_;

--- a/wicked/helpers/orbital_space.h
+++ b/wicked/helpers/orbital_space.h
@@ -83,7 +83,7 @@ public:
   std::string str() const;
 
   /// Return a dictionary representation
-  std::map<std::string, std::vector<std::string>> osi_dict() const;
+  std::map<std::string, std::vector<std::string>> to_dict() const;
 
 private:
   /// Vector of spaces

--- a/wicked/utils.py
+++ b/wicked/utils.py
@@ -1,6 +1,6 @@
 import wicked
 
-__all__ = ["string_to_expr", "gen_op"]
+__all__ = ["string_to_expr", "gen_op", "compile_einsum"]
 
 
 def string_to_expr(s):
@@ -54,3 +54,58 @@ def gen_op(label, rank, cre_spaces, ann_spaces, diagonal=True):
                             " ".join([s + "+" for s in le]) + " " + " ".join(re)
                         )
     return wicked.op(label, terms)
+
+def compile_einsum(equation):
+    """
+    Compile an equation into a valid einsum expression.
+    Turns a Wick&d equation (wicked._wicked.Equation) like H^{c0,a0}_{a1,a2} += 1/4 T2^{c0,a0}_{a3,a4} V^{a5,a6}_{a1,a2} eta1^{a4}_{a6} eta1^{a3}_{a5}
+    into the einsum code string "H_caaa += +0.25000000 * np.einsum('iuvw,xyzr,wr,vz->iuxy', T2['caaa'], V['aaaa'], eta1, eta1, optimize='optimal')"
+    """
+    def _get_unique_tensor_indices(tensor, unused_indices, index_dict):
+        indstr = ''
+        for i in tensor.upper()+tensor.lower():
+            i = str(i)
+            if index_dict.get(i):
+                indstr += index_dict[i]
+            else:
+                index = unused_indices[i[0]].pop(0)
+                index_dict[i] = index
+                indstr += index
+        
+        return indstr
+    
+    osi = wicked.osi()
+    unused_indices = osi.to_dict()
+    index_dict = {}
+
+    lhs = equation.lhs()
+    rhs = equation.rhs()
+    factor = equation.rhs_factor()
+
+    index_string = ''  # holds the expression part of the einsum contraction, e.g., iuvw,xyzr,wr,vz->iuxy 
+    tensor_label_string = '' # holds the tensor label part of the einsum contraction, e.g., T2['caaa'], V['aaaa'], eta1, eta1, optimize='optimal')
+
+    for t in rhs.tensors():
+        tensor_label_string += t.label() + "[\"" + ''.join([str(_)[0] for _ in t.upper()]) + ''.join([str(_)[0] for _ in t.lower()]) + "\"],"
+        index_string += _get_unique_tensor_indices(t, unused_indices, index_dict)
+        index_string += ','
+
+    index_string = index_string[:-1] + '->'
+    tensor_label_string += "optimize='optimal')"
+
+    if (lhs.tensors()[0].upper() != [] or lhs.tensors()[0].lower() != []): # If the lhs is not a scalar
+        left = rhs.tensors()[0].label()
+        left += ''.join([osi.label(_.space()) for _ in lhs.tensors()[0].upper()]) + ''.join([osi.label(_.space()) for _ in lhs.tensors()[0].lower()])
+        res_indx = _get_unique_tensor_indices(rhs.tensors(), unused_indices, index_dict)
+        index_string += res_indx
+    else: # If it's scalar, just return the label.
+        left = lhs.tensors()[0].label()
+
+    einsum_string = left \
+        + ' ' \
+        + f"+= {float(factor):+.8f} * np.einsum('"\
+        + index_string \
+        + "', " \
+        + tensor_label_string
+
+    return einsum_string


### PR DESCRIPTION
Exposes `SymbolicTerm`'s `tensors` function (amongst others) so that we can get the individual tensors in an expression. This enables the possibility for custom, Python-side code compilers.

To-do
- [x] Expose appropriate functions via pybind
- [x] Move compile to Python side