### PR TITLE
Support CMake 4 and modern Python toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 
 project(wicked)
 
@@ -6,5 +6,14 @@ set(CMAKE_CXX_STANDARD 20)
 
 option(CODE_COVERAGE "Enable coverage reporting" OFF)
 
-add_subdirectory(external/pybind11)
+# Prefer an installed pybind11 (find_package CONFIG); fall back to the
+# vendored submodule in external/pybind11 if none is found.
+find_package(pybind11 CONFIG QUIET)
+if(pybind11_FOUND)
+  message(STATUS "Using installed pybind11 ${pybind11_VERSION}")
+else()
+  message(STATUS "Using vendored pybind11 from external/pybind11")
+  add_subdirectory(external/pybind11)
+endif()
+
 add_subdirectory (wicked)


### PR DESCRIPTION
The project currently fails to **configure** on a current toolchain (CMake 4.x, Python 3.11+). This PR fixes both build-system blockers; they are independent of each other but both live in the top-level `CMakeLists.txt`.

### 1. `cmake_minimum_required(VERSION 3.1)` → `3.15`
CMake 4 removed compatibility with policy versions older than 3.5, so the old declaration is now a hard error:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

3.15 is comfortably within what the project actually uses.

### 2. Prefer an installed pybind11, fall back to the vendored submodule
The pinned `external/pybind11` submodule predates pybind11 2.10 and uses the now-opaque `PyFrameObject`, so it no longer compiles against Python 3.11+:

```
type_caster_base.h: error: invalid use of incomplete type 'PyFrameObject'
```

Switch to `find_package(pybind11 CONFIG)` and only `add_subdirectory(external/pybind11)` when no installed pybind11 is found. `wicked`'s own `pybind11_add_module` / `PYBIND11_MODULE` usage is unchanged, so the vendored path still works for anyone who relies on it.

### Verification
With these changes, a from-scratch `pip install .` configures and compiles cleanly against **CMake 4.3, Python 3.14, GCC 16.1** using an installed pybind11 (3.0.4), and the full test suite passes (78 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)