### PR TITLE
Package the wicked Python module in the built wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,10 +88,9 @@ setup(
     author="Francesco A. Evangelista",
     description="",
     long_description="",
-    # tell setuptools to look for any packages under 'wicked'
-    packages=find_packages("wicked"),
-    # tell setuptools that all packages will be under the 'wicked' directory
-    # and nowhere else
+    # ship the top-level 'wicked' Python package (__init__.py, utils.py)
+    # alongside the compiled _wicked extension built into it
+    packages=["wicked"],
     package_dir={"": "."},
     # add an extension module named 'wicked' to the package 'wicked'
     ext_modules=[CMakeExtension("wicked")],


### PR DESCRIPTION
`pip install .` builds the compiled extension correctly, but the resulting wheel ships **only** `_wicked.*.so` — `wicked/__init__.py` and `wicked/utils.py` are missing. As a result `import wicked` resolves to an empty namespace package (`wicked.__file__ is None`) with none of the public API:

```python
>>> import wicked; wicked.Index
AttributeError: module 'wicked' has no attribute 'Index'
```

The cause is the packaging config:

```python
packages=find_packages("wicked"),   # searches *inside* wicked/ for sub-packages
package_dir={"": "."},              # ...but maps the root to .
```

`find_packages("wicked")` looks for sub-packages under `wicked/` (the C++ source dirs, which aren't Python packages) and never returns the top-level `wicked` package itself, so its Python files are dropped from the wheel.

Listing the package explicitly fixes it:

```python
packages=["wicked"],
package_dir={"": "."},
```

### Verification
After this change a clean `pip install .` installs `__init__.py`, `utils.py`, and the extension together; `import wicked` resolves to the real package and exposes the full API; the test suite passes (78 passed). The editable/`develop` flow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)